### PR TITLE
Add shared GitHub Workflow for running Go tests

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily

--- a/.github/workflows/golang-library.yaml
+++ b/.github/workflows/golang-library.yaml
@@ -1,0 +1,37 @@
+name: go
+on:
+  workflow_call:
+    inputs:
+      setup_terraform:
+        type: boolean
+        description: "Install Terraform"
+        default: false
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.19', '1.20']
+    steps:
+      # Checkout repo to GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Install Go
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{matrix.go}}
+
+      # Install Terraform
+      - name: Setup Terraform
+        if: ${{ inputs.setup_terraform }}
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_wrapper: false
+
+      # Test
+      - name: Go Test
+        run: make

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# .github
+
+`.github` centrally manages GitHub Workflows, issue templates, and more for [dghubble](https://github.com/dghubble) public repos.
+


### PR DESCRIPTION
* Add golang-library for running Go tests on Go package projects
  * Matrix test Go 1.19 and 1.20 in parallel
  * Use setup-go Action with cache enabled by default
  *  Optionally setup Terraform for use in Terraform provider tests
* Configure dependabot to watch for GitHub Actions updates