### PR TITLE
Update golang-library Workflow to target the stable Go version

### DIFF
--- a/.github/workflows/golang-library.yaml
+++ b/.github/workflows/golang-library.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.21']
+        go: ['stable']
     steps:
       # Checkout repo to GitHub Actions runner
       - name: Checkout


### PR DESCRIPTION
* Stop tracking individual Go versions and just track to current stable version. I don't have time to keep bumping this manually